### PR TITLE
Document and test Rust 1.59.0 as minimum supported version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
         rust:
           - nightly
 
+          # Minimum supported version.
+          # Keep this in sync with Cargo.toml and README.md
+          - 1.59.0
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -23,32 +27,32 @@ jobs:
           components: rust-src, rustfmt, clippy
 
       - name: Setup QEMU
+        if: ${{ matrix.rust == 'nightly' }}
         run: sudo apt-get update && sudo apt-get install -y qemu-system-x86
 
-      - name: Build as x86_64
+      - name: Build (without testing) as x86_64
+        if: ${{ matrix.rust == 'nightly' }} # Tier 2 (precompiled libcore in rustup) since 1.62
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --target x86_64-unknown-none
 
-      - name: Build as i686
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target i686-unknown-none.json
-
-      - name: Test
+      - name: Build and test as i686
+        if: ${{ matrix.rust == 'nightly' }}
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --target i686-unknown-none.json
 
       - name: Rustfmt
+        if: ${{ matrix.rust == 'nightly' }}
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
 
       - name: Clippy
+        if: ${{ matrix.rust == 'nightly' }}
         uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           components: rust-src, rustfmt, clippy
 
       - name: Setup QEMU
-        run: sudo apt-get install -y qemu-system-x86
+        run: sudo apt-get update && sudo apt-get install -y qemu-system-x86
 
       - name: Build as x86_64
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["qemu", "fw_cfg"]
 categories = ["no-std", "embedded", "hardware-support"]
 readme = "README.md"
 
+# Keep this in sync with README.md and .github/workflows/ci.yml
+rust-version = "1.59"
+
 [features]
 default = ["alloc"]
 alloc = []

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ if running_in_qemu() {
 
 ## Rust support
 
-Currently, `qemu-fw-cfg` required nightly compiler to build.
+<!-- Keep this in sync with Cargo.toml and .github/workflows/ci.yml -->
+The minimum supported Rust version for `qemu-fw-cfg` is 1.59.0.
+
+However, testing for x86 currently requires Rust Nightly as it uses
+[Cargo’s `build-std`](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std).
 
 ## License
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ impl FwCfg {
 const FW_CFG_FILE_SIZE: usize = 64;
 
 /// A struct that contains information of a fw_cfg file.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FwCfgFile<'a> {
     size: usize,
     key: u16,

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(default_alloc_error_handler)]
+#![cfg_attr(feature = "alloc", feature(default_alloc_error_handler))]
 
 use qemu_fw_cfg::FwCfg;
 
@@ -42,6 +42,7 @@ fn main() {
     );
 
     // Read file
+    #[cfg(feature = "alloc")]
     assert_eq!(DATA_INPUT_TXT, fw_cfg.read_file(&file_input_txt));
 
     // Read file with buffer


### PR DESCRIPTION
1.59.0 is the version that stabilized the asm! macro for inline assembly.

The README previously said that Nightly is required, but that turned to be the case only for cross-compiling to i686-unknown-none.